### PR TITLE
new changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+.env

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+.env

--- a/server/package.json
+++ b/server/package.json
@@ -19,8 +19,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "graphql": "^16.9.0",
-    "graphql-iso-date": "^3.6.1",
-    "graphql-tag": "^2.12.6",
+    
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.5.1"
   },


### PR DESCRIPTION
removed the following dependencies from the server package.json: graphql-iso-date: ^3.6.1,
    graphql-tag: ^2.12.6,
this files were preventing the server installation of dependencies ( npm i)  to work in windows added .gitignore to the server and personal finance tracker folders to include the .env and node_modules